### PR TITLE
RIFEX-245/Add-block-To-Chainaddresses

### DIFF
--- a/src/main/java/org/rif/notifier/managers/DbManagerFacade.java
+++ b/src/main/java/org/rif/notifier/managers/DbManagerFacade.java
@@ -221,7 +221,7 @@ public class DbManagerFacade {
     @Transactional
     public List<ChainAddressEvent> saveChainAddressesEvents(List<ChainAddressEvent> chainAddressEvents){
         return chainAddressEvents.stream().map(chainAddressEvent ->
-                chainAddressManager.insert(chainAddressEvent.getNodehash(), chainAddressEvent.getEventName(), chainAddressEvent.getChain(), chainAddressEvent.getAddress(), chainAddressEvent.getRowhashcode())
+                chainAddressManager.insert(chainAddressEvent.getNodehash(), chainAddressEvent.getEventName(), chainAddressEvent.getChain(), chainAddressEvent.getAddress(), chainAddressEvent.getRowhashcode(), chainAddressEvent.getBlock())
         ).collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/rif/notifier/managers/datamanagers/ChainAddressManager.java
+++ b/src/main/java/org/rif/notifier/managers/datamanagers/ChainAddressManager.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -26,8 +27,8 @@ public class ChainAddressManager {
     @Value("${notifier.notifications.maxquerylimit}")
     private int MAX_LIMIT_QUERY;
 
-    public ChainAddressEvent insert(String nodehash, String eventName, String chain, String address, int hashcode) {
-        ChainAddressEvent evnt = new ChainAddressEvent(nodehash, eventName, chain, address, hashcode);
+    public ChainAddressEvent insert(String nodehash, String eventName, String chain, String address, int hashcode, BigInteger block) {
+        ChainAddressEvent evnt = new ChainAddressEvent(nodehash, eventName, chain, address, hashcode, block);
         ChainAddressEvent result = chainAddressRepository.save(evnt);
         return result;
     }

--- a/src/main/java/org/rif/notifier/models/entities/ChainAddressEvent.java
+++ b/src/main/java/org/rif/notifier/models/entities/ChainAddressEvent.java
@@ -3,6 +3,7 @@ package org.rif.notifier.models.entities;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import javax.persistence.*;
+import java.math.BigInteger;
 
 @Entity
 @Table(name = "chainaddress_event")
@@ -23,21 +24,25 @@ public class ChainAddressEvent {
     @Column(name = "hashcode")
     private int rowhashcode;
 
+    private BigInteger block;
+
     public ChainAddressEvent() {}
 
-    public ChainAddressEvent(String nodehash, String eventName, String chain, String address) {
+    public ChainAddressEvent(String nodehash, String eventName, String chain, String address, BigInteger block) {
         this.nodehash = nodehash;
         this.eventName = eventName;
         this.chain = chain;
         this.address = address;
+        this.block = block;
     }
 
-    public ChainAddressEvent(String nodehash, String eventName, String chain, String address, int rowhashcode) {
+    public ChainAddressEvent(String nodehash, String eventName, String chain, String address, int rowhashcode, BigInteger block) {
         this.nodehash = nodehash;
         this.eventName = eventName;
         this.chain = chain;
         this.address = address;
         this.rowhashcode = rowhashcode;
+        this.block = block;
     }
 
     public int getId() {
@@ -88,6 +93,14 @@ public class ChainAddressEvent {
         this.rowhashcode = rowhashcode;
     }
 
+    public BigInteger getBlock() {
+        return block;
+    }
+
+    public void setBlock(BigInteger block) {
+        this.block = block;
+    }
+
     @Override
     public int hashCode() {
         return new HashCodeBuilder(17, 37)
@@ -95,6 +108,7 @@ public class ChainAddressEvent {
                 .append(eventName)
                 .append(chain)
                 .append(address)
+                .append(block)
                 .toHashCode();
     }
 }

--- a/src/main/java/org/rif/notifier/scheduled/DataFetchingJob.java
+++ b/src/main/java/org/rif/notifier/scheduled/DataFetchingJob.java
@@ -234,7 +234,7 @@ public class DataFetchingJob {
                         String nodehash = Numeric.toHexString((byte[]) item.getValues().get(0).getValue());
                         String eventName = "AddrChanged";
                         String address = item.getValues().get(1).getValue().toString();
-                        ChainAddressEvent rskChain = new ChainAddressEvent(nodehash, eventName, RSK_SLIP_ADDRESS, address);
+                        ChainAddressEvent rskChain = new ChainAddressEvent(nodehash, eventName, RSK_SLIP_ADDRESS, address, item.getBlockNumber());
                         rskChain.setRowhashcode(rskChain.hashCode());
                         if (dbManagerFacade.getChainAddressEventByHashcode(rskChain.getRowhashcode()) == null) {
                             chainsEvents.add(rskChain);
@@ -246,7 +246,7 @@ public class DataFetchingJob {
                         String chain = Numeric.toHexString((byte[]) item.getValues().get(1).getValue());
                         String address = item.getValues().get(2).getValue().toString();
                         String eventName = "ChainAddrChanged";
-                        ChainAddressEvent chainAddr = new ChainAddressEvent(nodehash, eventName, chain, address);
+                        ChainAddressEvent chainAddr = new ChainAddressEvent(nodehash, eventName, chain, address, item.getBlockNumber());
                         chainAddr.setRowhashcode(chainAddr.hashCode());
                         if (dbManagerFacade.getChainAddressEventByHashcode(chainAddr.getRowhashcode()) == null) {
                             chainsEvents.add(chainAddr);

--- a/src/main/resources/db_dumps/Dump20200714.sql
+++ b/src/main/resources/db_dumps/Dump20200714.sql
@@ -28,6 +28,7 @@ CREATE TABLE `chainaddress_event` (
   `event_name` varchar(45) DEFAULT NULL,
   `chain` varchar(100) DEFAULT NULL,
   `address` varchar(100) DEFAULT NULL,
+  `block` bigint(45) NOT NULL,
   `hashcode` varchar(100) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=772 DEFAULT CHARSET=latin1;


### PR DESCRIPTION
This PR adds a block column to the chainaddresses events, and change the hashcode to take account of it